### PR TITLE
Support rubocop --require option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Or install it yourself as:
 
     Usage: rubocop-git [options] [[commit] commit]
         -c, --config FILE                Specify configuration file
+        -r, --require FILE               Require Ruby file
         -d, --debug                      Display debug info
         -D, --display-cop-names          Display cop names in offense messages
             --cached                     git diff --cached

--- a/lib/rubocop/git/cli.rb
+++ b/lib/rubocop/git/cli.rb
@@ -30,6 +30,11 @@ module RuboCop
             @options.config = config
           end
 
+          opt.on('-r', '--require FILE',
+                 'Require Ruby file') do |file|
+            require file
+          end
+
           opt.on('-d', '--debug', 'Display debug info') do
             @options.rubocop[:debug] = true
           end


### PR DESCRIPTION
Support rubocop --require option (rubocop [source](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/options.rb#L77)) so that we can use custom cops (e.g., [rubocop-rspec](https://github.com/nevir/rubocop-rspec#command-line)) by rubocop-git!
