### PR TITLE
Program should exit with nonzero code for scripting

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -11,6 +11,8 @@ module RuboCop
         @files = DiffParser.parse(git_diff(options))
 
         display_violations($stdout)
+        
+        exit(1) if violations.any?
       end
 
       private


### PR DESCRIPTION
1 is better than zero.

This allows trivial git hooks, such as:

``` sh
# .git/hooks/pre-commit
rubocop-git --cached
```

The git commit will then abort if you haven't met the rubocop style guidelines.
