### PR TITLE
Add Paths Support

### DIFF
--- a/lib/rubocop/git/cli.rb
+++ b/lib/rubocop/git/cli.rb
@@ -44,6 +44,12 @@ module RuboCop
             @options.rubocop[:display_cop_names] = true
           end
 
+          opt.on('-p',
+                 '--paths PATHS',
+                 'Limit diff to the named path(s)') do |paths|
+            @options.paths = paths
+          end
+
           opt.on('--cached', 'git diff --cached') do
             @options.cached = true
           end

--- a/lib/rubocop/git/options.rb
+++ b/lib/rubocop/git/options.rb
@@ -7,7 +7,7 @@ module RuboCop
         File.expand_path('../../../../hound.yml', __FILE__)
 
       attr_accessor :config
-      attr_reader   :cached, :hound, :rubocop
+      attr_reader   :cached, :hound, :rubocop, :paths
 
       def initialize(hash_options = nil)
         @config  = nil
@@ -15,6 +15,7 @@ module RuboCop
         @hound   = false
         @rubocop = {}
         @commits = []
+        @paths   = []
 
         from_hash(hash_options) if hash_options
       end
@@ -47,6 +48,13 @@ module RuboCop
         @commits = commits
       end
 
+      def paths=(path)
+        @paths = path.split ' '
+        @paths.unshift '--' if @paths.any?
+      rescue
+        fail Invalid, "invalid paths: #{paths.inspect}"
+      end
+
       def config_file
         if hound
           HOUND_DEFAULT_CONFIG_FILE
@@ -71,7 +79,7 @@ module RuboCop
 
       def from_hash(hash_options)
         hash_options = hash_options.dup
-        %w(config cached hound rubocop commits).each do |key|
+        %w(config cached hound rubocop commits paths).each do |key|
           public_send("#{key}=", hash_options.delete(key))
         end
         unless hash_options.empty?

--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -8,10 +8,10 @@ module RuboCop
         options = Options.new(options) unless options.is_a?(Options)
 
         @options = options
-        @files = DiffParser.parse(git_diff(options))
+        @files = DiffParser.parse(git_diff)
 
         display_violations($stdout)
-        
+
         exit(1) if violations.any?
       end
 
@@ -32,17 +32,8 @@ module RuboCop
         @pull_request ||= PseudoPullRequest.new(@files, @options)
       end
 
-      def git_diff(options)
-        args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
-
-        if options.cached
-          args << '--cached'
-        elsif options.commit_last
-          args << options.commit_first.shellescape
-          args << options.commit_last.shellescape
-        end
-
-        `git #{args.join(' ')}`
+      def git_diff
+        `git #{diff_args.join ' '}`
       end
 
       def display_violations(io)
@@ -57,6 +48,19 @@ module RuboCop
         end
 
         formatter.finished(@files.map(&:filename).freeze)
+      end
+
+      def diff_args
+        args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
+
+        if @options.cached
+          args << '--cached'
+        elsif @options.commit_last
+          args << @options.commit_first.shellescape
+          args << @options.commit_last.shellescape
+        end
+
+        args.concat @options.paths
       end
     end
   end


### PR DESCRIPTION
**What's New?**
This adds support for specifying a path, or paths you wish to restrict the diff to. For example, to run rubocop on a single file, you can now use the "-p" or "--paths" option.

```rubocop-git --paths 'path/to/foo.rb' develop master```

You can also specify multiple paths.

```rubocop-git --paths 'path/to/models path/to/controllers' develop master```

**What's Changed?**
Building the diff command args has been abstracted into it's own method, simplifying the git_diff method.