### PR TITLE
Allow single commit so that working tree changes can be included.

### DIFF
--- a/lib/rubocop/git/options.rb
+++ b/lib/rubocop/git/options.rb
@@ -60,11 +60,11 @@ module RuboCop
       end
 
       def commit_first
-        @commits.length == 1 ? @commits.first + '^' : @commits.first
+        @commits.first
       end
 
       def commit_last
-        @commits.last
+        @commits.length == 1 ? false : @commits.last
       end
 
       private

--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -35,12 +35,9 @@ module RuboCop
       def git_diff(options)
         args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
 
-        if options.cached
-          args << '--cached'
-        elsif options.commit_last
-          args << options.commit_first.shellescape
-          args << options.commit_last.shellescape
-        end
+        args << '--cached' if options.cached
+        args << options.commit_first.shellescape if options.commit_first
+        args << options.commit_last.shellescape if options.commit_last
 
         `git #{args.join(' ')}`
       end

--- a/lib/rubocop/git/version.rb
+++ b/lib/rubocop/git/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Git
-    VERSION = '0.0.4'
+    VERSION = '0.0.5'
   end
 end

--- a/rubocop-git.gemspec
+++ b/rubocop-git.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
 
-  spec.add_dependency 'rubocop', '>= 0.24.1'
+  spec.add_dependency 'rubocop', '>= 0.31.0'
 end


### PR DESCRIPTION
It is assumed when providing one commit, the previous commit and the provided commit were to be used.

rubocop-git should behave more like git, where providing one commit means comparing your changes to that commit.