### PR TITLE
Fix false positive for snake case violation

### DIFF
--- a/lib/rubocop/git/style_guide.rb
+++ b/lib/rubocop/git/style_guide.rb
@@ -29,7 +29,7 @@ class StyleGuide
   end
 
   def parse_source(file)
-    RuboCop::ProcessedSource.new(file.content)
+    RuboCop::ProcessedSource.new(file.content, file.filename)
   end
 
   def config


### PR DESCRIPTION
Fixes #5 

The invocation of `ProcessedSource.new` should pass the file name, so RuboCop::ProcessedSource, and thus the file_name cop  has access to it. Without the file name, the cop incorrectly reports a violation. Now, you could say this is a bug with that cop. It should be saying "ignoring cop since there is no file name", instead of reporting a violation. Until that is fixed, this PR just avoids the issue and results in a working file_name cop, and is necessary regardless.

For reference:
- ProcessedSource: https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/processed_source.rb#L22
- file_name cop: https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/file_name.rb#L13
