### PR TITLE
Fix rubocop complaining about absolete configuration

### DIFF
--- a/hound.yml
+++ b/hound.yml
@@ -188,7 +188,10 @@ StringLiterals:
 VariableInterpolation:
   Enabled: false
 
-TrailingComma:
+TrailingCommaInArguments:
+  Enabled: false
+
+TrailingCommaInLiteral:
   Enabled: false
 
 TrivialAccessors:


### PR DESCRIPTION
Running the rubocop v0.1.1 wield yield this error:

```
/Users/amree/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/rubocop-0.37.2/lib/rubocop/config.rb:270:in `block in reject_obsolete_cops': The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead. (RuboCop::ValidationError)
(obsolete configuration found in /Users/amree/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/rubocop-git-0.1.1/hound.yml, please update it)
        from /Users/amree/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/rubocop-0.37.2/lib/rubocop/config.rb:266:in `each'
...
```

This pull request should fix it. Changes are referenced from https://github.com/bbatsov/rubocop/blob/master/config/default.yml
