### PR TITLE
Fix a bug where rubocop:disable wasn't being respected

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -49,7 +49,7 @@ module RuboCop
         violations.map do |violation|
           formatter.file_finished(
             violation.filename,
-            violation.offenses.compact.sort.freeze
+            violation.offenses.reject(&:disabled?).compact.sort.freeze
           )
         end
 

--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -47,9 +47,11 @@ module RuboCop
         formatter.started(nil)
 
         violations.map do |violation|
+          offenses = violation.offenses
+          offenses = offenses.reject(&:disabled?) if offenses.first.respond_to?(:disabled?)
           formatter.file_finished(
             violation.filename,
-            violation.offenses.reject(&:disabled?).compact.sort.freeze
+            offenses.compact.sort.freeze
           )
         end
 


### PR DESCRIPTION
Resolves #17 

I spent a while this morning looking into this, and finally realized that everything in rubocop is working correctly, but when it passes the offenses back, it also includes disabled offenses (which is actually kinda strange, but whatever). The fix was to filter out the disabled offenses before displaying them.
