### PR TITLE
Fix Exclude bug

### DIFF
--- a/lib/rubocop/git/pseudo_resource.rb
+++ b/lib/rubocop/git/pseudo_resource.rb
@@ -1,11 +1,15 @@
 module RuboCop
   module Git
     class PseudoResource
-      attr_reader :filename, :patch
+      attr_reader :patch
 
       def initialize(filename)
         @filename = filename
         @patch    = ''
+      end
+
+      def filename
+        "#{Dir.pwd}/#{@filename}"
       end
 
       def status


### PR DESCRIPTION
Before, if you did something like:

````yml
Documentation:
  Exclude:
    - 'subdir/**/*.rb'
````

It wouldn't actually exclude that. It was because rubocop looks for those exclusions using an absolute path for the file name.