### PR TITLE
Reset git diff settings for color and mnemonicprefix to default

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -33,7 +33,7 @@ module RuboCop
       end
 
       def git_diff(options)
-        args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
+        args = %w(-c diff.mnemonicprefix=false diff --no-color --diff-filter=AMCR --find-renames --find-copies)
 
         args << '--cached' if options.cached
         args << options.commit_first.shellescape if options.commit_first


### PR DESCRIPTION
Resetting:

-  color setting via `--no-color`
- diff.mnemonicprefix via `-c diff.mnemonicprefix=false`

Addresses https://github.com/m4i/rubocop-git/issues/20