### PR TITLE
Add auto_correct

### DIFF
--- a/lib/rubocop/git/cli.rb
+++ b/lib/rubocop/git/cli.rb
@@ -60,6 +60,10 @@ module RuboCop
             puts RuboCop::Git::VERSION
             exit 0
           end
+
+          opt.on('-a', '--auto-correct', 'Auto-correct offenses') do
+            @options.rubocop[:auto_correct] = true
+          end
         end
       end
     end


### PR DESCRIPTION
Pulls in the `-a`/`--auto-correct` option from rubocop, which I've found immensely useful recently