### PR TITLE
Use --no-color for git diffs

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -33,7 +33,7 @@ module RuboCop
       end
 
       def git_diff(options)
-        args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
+        args = %w(diff --diff-filter=AMCR --find-renames --find-copies --no-color)
 
         args << '--cached' if options.cached
         args << options.commit_first.shellescape if options.commit_first


### PR DESCRIPTION
It took me a while to figure out why I was never getting results when running this gem, but I eventually tracked it down to my git config having `git config color.ui` set to `always` instead of `auto`. This was including ANSI color codes in the diffs and causing the parser to not match on anything.

> The default setting is auto, which colors output when it’s going straight to a terminal, but omits the color-control codes when the output is redirected to a pipe or a file.
> You can also set it to always to ignore the difference between terminals and pipes.

I think this will make the gem a bit more robust for anyone else that runs across the same issue.