### PR TITLE
Do not include violations that don't have any offenses

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -18,7 +18,10 @@ module RuboCop
       private
 
       def violations
-        @violations ||= style_checker.violations
+        @violations ||= style_checker.violations.reject do |violation|
+          next false unless violation.offenses.first.respond_to?(:disabled?)
+          violation.offenses.all?(&:disabled?)
+        end
       end
 
       def style_checker


### PR DESCRIPTION
The `rubocop-git` command exits with exit code 1, but the console output says no offenses.

This is because it doesn't display disabled offenses, and if all offenses are disabled under a violation, it just says there are no offenses. But when it determines whether it should `exit(1)`, it just sees if there are any violations.