### PR TITLE
only exit from cli

### DIFF
--- a/lib/rubocop/git/cli.rb
+++ b/lib/rubocop/git/cli.rb
@@ -7,7 +7,11 @@ module RuboCop
       def run(args = ARGV)
         @options = Options.new
         parse_arguments(args)
-        Runner.new.run(@options)
+        if Runner.new.run(@options)
+          exit
+        else
+          exit 1
+        end
       end
 
       private

--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -12,7 +12,7 @@ module RuboCop
 
         display_violations($stdout)
 
-        exit(1) if violations.any?
+        violations.empty?
       end
 
       private

--- a/test/rubocop/git/cli_test.rb
+++ b/test/rubocop/git/cli_test.rb
@@ -2,6 +2,16 @@ require_relative '../../test_helper'
 require 'rubocop/git/cli'
 
 describe RuboCop::Git::CLI do
+  it 'exit with violations' do
+    # lib/rubocop/git/runner.rb:14:1: C: Trailing whitespace detected.
+    commits = ["v0.0.4", "v0.0.5"]
+    proc do
+      _out, _err = capture_io do
+        RuboCop::Git::CLI.new.run(commits)
+      end
+    end.must_raise(SystemExit)
+  end
+
   it 'fail with invalid options' do
     proc do
       _out, _err = capture_io do

--- a/test/rubocop/git/runner_test.rb
+++ b/test/rubocop/git/runner_test.rb
@@ -2,15 +2,11 @@ require_relative '../../test_helper'
 require 'rubocop/git/runner'
 
 describe RuboCop::Git::Runner do
-  it 'exit with violations' do
+  it 'returns false' do
     options = RuboCop::Git::Options.new
     # lib/rubocop/git/runner.rb:14:1: C: Trailing whitespace detected.
     options.commits = ["v0.0.4", "v0.0.5"]
-    proc do
-      _out, _err = capture_io do
-        RuboCop::Git::Runner.new.run(options)
-      end
-    end.must_raise(SystemExit)
+    refute(RuboCop::Git::Runner.new.run(options))
   end
 
   it 'fail with no options' do


### PR DESCRIPTION
This allows you to use Rubocop-Git in a running ruby process without exiting. Useful for CI.